### PR TITLE
iframe do google calendar em darkmode + blur background

### DIFF
--- a/Assets/css/style.css
+++ b/Assets/css/style.css
@@ -4,6 +4,8 @@ body {
     margin: 0;
     padding: 0;
     background-image: url("../img/bg.png");
+    backdrop-filter: blur(100px);
+    -webkit-backdrop-filter: blur(100px);
     background-repeat: no-repeat;
     background-size: cover;
     min-height: 100vh; 
@@ -77,10 +79,21 @@ body > div {
     overflow: hidden;
 }
 
-.calendar iframe {
-    width: 100%;
-    height: 100%;
-    border: none;
+/* Estilo do iframe - dark mode*/
+.calendar-iframe {
+    filter: invert(1) hue-rotate(180deg);
+    background-color: #000;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: transparent;
+    border-radius: 10px;
+    margin-top: 25px;
+    margin-left: auto;
+    margin-right: auto;
+    width: 95%;
+    height: 450px;
+    overflow: hidden;         
 }
 
 /* Media queries */

--- a/index.html
+++ b/index.html
@@ -38,17 +38,9 @@
             <li class="nav-link">Importar Agenda</li>
             <li class="nav-link">Comunidade</li>
         </ul>
-    </div>
-    <div class="calendar">
-        <iframe src="https://calendar.google.com/calendar/embed?height=600&wkst=1&bgcolor=%23ffffff&ctz=America%2FFortaleza&title=Coders%20Ceara&src=Y29kZXJzY2VhcmFAZ21haWwuY29t&src=YWRkcmVzc2Jvb2sjY29udGFjdHNAZ3JvdXAudi5jYWxlbmRhci5nb29nbGUuY29t&src=cHQtYnIuYnJhemlsaWFuI2hvbGlkYXlAZ3JvdXAudi5jYWxlbmRhci5nb29nbGUuY29t&color=%23039BE5&color=%2333B679&color=%23"></iframe>    
+    </div>   
+        <iframe class="calendar-iframe" src="https://calendar.google.com/calendar/embed?ctz=America%2FFortaleza&title=Coders%20Ceara&src=Y29kZXJzY2VhcmFAZ21haWwuY29t&src=YWRkcmVzc2Jvb2sjY29udGFjdHNAZ3JvdXAudi5jYWxlbmRhci5nb29nbGUuY29t&src=cHQtYnIuYnJhemlsaWFuI2hvbGlkYXlAZ3JvdXAudi5jYWxlbmRhci5nb29nbGUuY29t" width="800" height="600" frameborder="0" scrolling="no"></iframe>
     
-        <!-- A seguinte solução não funcionou -->
-        <!-- 
-        <iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;ctz=America%2FFortaleza&amp;title=Coders%20Ceara&amp;src=Y29kZXJzY2VhcmFAZ21haWwuY29t&amp;src=YWRkcmVzc2Jvb2sjY29udGFjdHNAZ3JvdXAudi5jYWxlbmRhci5nb29nbGUuY29t&amp;src=cHQtYnIuYnJhemlsaWFuI2hvbGlkYXlAZ3JvdXAudi5jYWxlbmRhci5nb29nbGUuY29t&amp;color=%23039BE5&amp;color=%2333B679&amp;color=%23"
-        style="border-width: 0; width: 800px; height: 600px;background-color: #222222; margin: 0 auto;"
-        frameborder="0" scrolling="no"></iframe>
-        -->
-    </div>
     <script src="Assets/js/index.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Foi aplicado um filtro de inversão de cores (invert(1)) e uma rotação de matiz de 180 graus (hue-rotate(180deg)) pra criar um efeito dark mode, definindo a cor de fundo como preto (#000). Além disso, foi adicionado - apenas como sugestão - um efeito blur no bg.
